### PR TITLE
add multilanguage support to computop iframes

### DIFF
--- a/lib/CTPayment/CTEnums/CTEnumLanguages.php
+++ b/lib/CTPayment/CTEnums/CTEnumLanguages.php
@@ -1,0 +1,103 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+
+/**
+ * The Computop Shopware Plugin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * The Computop Shopware Plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Computop Shopware Plugin. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * PHP version 5.6, 7.0 , 7.1
+ *
+ * @category   Payment
+ * @package    FatchipCTPayment
+ * @subpackage CTPayment_CTEnums
+ * @author     FATCHIP GmbH <support@fatchip.de>
+ * @copyright  2018 Computop
+ * @license    <http://www.gnu.org/licenses/> GNU Lesser General Public License
+ * @link       https://www.computop.com
+ */
+
+
+namespace Fatchip\CTPayment\CTEnums;
+
+/**
+ * Class CTEnumEasyCredit
+ * @package Fatchip\CTPayment\CTEnums
+ */
+class CTEnumLanguages
+{
+    const DEFAULT_LANGUAGE = 'de';
+
+    // ISO-639-1 codes of languages supported by CompuTop
+    const supportedLanguages = [
+        'de',
+        'al',
+        'cs',
+        'da',
+        'dk',
+        'en',
+        'fi',
+        'fr',
+        'el',
+        'hu',
+        'it',
+        'jp',
+        'hu',
+        'it',
+        'ja',
+        'nl',
+        'no',
+        'pl',
+        'pt',
+        'ro',
+        'ru',
+        'es',
+        'se',
+        'sk',
+        'sl',
+        'tr',
+        'zh',
+    ];
+
+    // ISO-631-1 => CompuTop
+    const languageCodeMap = [
+        'cs' => 'cz',
+        'da' => 'dk',
+        'el' => 'gr',
+        'ja' => 'jp',
+        'nb' => 'no',
+        'nn' => 'no',
+    ];
+
+    /**
+     * Determine the CompuTop language code to use for a given ISO-631-1 language
+     *
+     * @param string|null $isoLanguage
+     * @return mixed|string
+     */
+    public static function getComputopLanguageCode($isoLanguage)
+    {
+        if ($isoLanguage === null || $isoLanguage === '') {
+            return self::DEFAULT_LANGUAGE;
+        }
+
+        if (!in_array($isoLanguage, self::supportedLanguages)) {
+            return self::DEFAULT_LANGUAGE;
+        }
+
+        if (array_key_exists($isoLanguage, self::languageCodeMap)) {
+            return self::languageCodeMap[$isoLanguage];
+        }
+
+        return $isoLanguage;
+    }
+}

--- a/lib/CTPayment/CTPaymentMethod.php
+++ b/lib/CTPayment/CTPaymentMethod.php
@@ -40,7 +40,13 @@ abstract class CTPaymentMethod extends Blowfish
     /**
      * These params should not be send with the computop requests and are filtered out in prepareComputopRequest
      */
-    const paramexcludes = ['MAC' => 'MAC', 'mac' => 'mac', 'blowfishPassword' => 'blowfishPassword', 'merchantID' => 'merchantID'];
+    const paramexcludes = [
+        'blowfishPassword' => 'blowfishPassword',
+        'Language' => 'Language',
+        'MAC' => 'MAC',
+        'mac' => 'mac',
+        'merchantID' => 'merchantID',
+    ];
 
     /**
      * Vom Paygate vergebene ID für die Zahlung. Z.B. zur Referenzierung in Batch-Dateien.

--- a/lib/CTPayment/CTPaymentMethodIframe.php
+++ b/lib/CTPayment/CTPaymentMethodIframe.php
@@ -27,6 +27,7 @@
 
 namespace Fatchip\CTPayment;
 
+use Fatchip\CTPayment\CTEnums\CTEnumLanguages;
 use Fatchip\CTPayment\CTOrder;
 use Shopware\Plugins\FatchipCTPayment\Util;
 
@@ -49,6 +50,13 @@ abstract class CTPaymentMethodIframe extends CTPaymentMethod
      * @var string
      */
     protected $currency = 'EUR';
+
+    /**
+     * Shop ISO-639-1 language code
+     *
+     * @var string $language
+     */
+    protected $language = 'de';
 
     /**
      * Wenn beim Aufruf angegeben, übergibt das Paygate die Parameter mit dem Zahlungsergebnis an den Shop
@@ -286,6 +294,26 @@ abstract class CTPaymentMethodIframe extends CTPaymentMethod
     }
 
     /**
+     * Language setter
+     *
+     * @param $language
+     */
+    public function setLanguage($language)
+    {
+        $this->language = $language;
+    }
+
+    /**
+     * Language getter
+     *
+     * @return string
+     */
+    public function getLanguage()
+    {
+        return $this->language;
+    }
+
+    /**
      * @ignore <description>
      * @param string $UserData
      */
@@ -465,6 +493,19 @@ abstract class CTPaymentMethodIframe extends CTPaymentMethod
     public function getHTTPGetURL($ctRequest)
     {
         return $this->prepareComputopRequest($ctRequest, $this->getCTPaymentURL());
+    }
+
+    /**
+     * Prepares CT Request. Takes all params, creates a querystring, determines Length and encrypts the data
+     *
+     * @param $params
+     * @param $url
+     * @return string
+     */
+    public function prepareComputopRequest($params, $url)
+    {
+        $url = parent::prepareComputopRequest($params, $url);
+        return $url . '&Language=' . CTEnumLanguages::getComputopLanguageCode($this->getLanguage());
     }
 
     /**


### PR DESCRIPTION
The shopware plugin will currently not pass any language parameter to CompuTop IFrames, meaning the IFrame content will always be german even if the subshop has a different language configured that computop supports.

This PR by itself will cause the parameter Language=de to be appended to the IFrame URL.
I will create a related PR in the shopware plugin repo that handles determining the shop language in the CTPayment controller.

If the Non-Iframe payment methods could profit from this as well it should be trivial to support them, but i didn't look into that too much because we don't use those and needed a solution fast.

PS: I know the Enum class does more than just enumeration, but i had to add some mapping code since CompuTop uses their own special brand of language codes. I didn't see a more fitting namespace for that and putting that code in the CTPaymentIframe class felt wrong.

